### PR TITLE
Add công thức tính thêm tổng chi của tháng vào dashboard (status approved)

### DIFF
--- a/aspnet-core/src/FinanceManagement.Core/Managers/Dashboards/DashboardManager.cs
+++ b/aspnet-core/src/FinanceManagement.Core/Managers/Dashboards/DashboardManager.cs
@@ -987,12 +987,14 @@ namespace FinanceManagement.Managers.Dashboards
                     TotalVND = x.Sum(s => s.TotalVND)
                 })
                 .ToDictionary(x => x.BranchId, x => x.TotalVND);
+            var tongGiaoDichTheoBranchRequestApproved = await GetTongGiaoDichTheoChiNhanhRequestApproved(dicCurrencyConvert, startDate, endDate);
             //lay theo thu
             var qtongThu = await GetDataBaoCaoThu(startDate, endDate, dicCurrencyConvert, null);
 
             foreach (var dto in tongChiTheoChiNhanh)
             {
                 dto.TongChiThuc = tongChiThucTheoChiNhanh.ContainsKey(dto.BranchId) ? tongChiThucTheoChiNhanh[dto.BranchId] : 0;
+                dto.TongGiaoDichNganHangApproved = tongGiaoDichTheoBranchRequestApproved.ContainsKey(dto.BranchId) ? tongGiaoDichTheoBranch[dto.BranchId] : 0;
             }
 
             var tong = new BaoCaoChungDto
@@ -1001,7 +1003,8 @@ namespace FinanceManagement.Managers.Dashboards
                 TongThu = qtongThu.Sum(x => x.TotalVND),
                 TongThuThuc = qtongThu.Where(x => x.IsDoanhThu).Sum(x => x.TotalVND),
                 TongChi = tongChiTheoChiNhanh.Sum(x => x.TongChi),
-                TongChiThuc = tongChiTheoChiNhanh.Sum(x => x.TongChiThuc)
+                TongChiThuc = tongChiTheoChiNhanh.Sum(x => x.TongChiThuc),
+                TongGiaoDichNganHangApproved = tongChiTheoChiNhanh.Sum(x => x.TongGiaoDichNganHangApproved)
             };
             tongChiTheoChiNhanh.Add(tong);
 
@@ -1093,6 +1096,35 @@ namespace FinanceManagement.Managers.Dashboards
                 OutcomingEntryType = x.OutcomingEntryType,
                 Details = x.Details
             }).OrderBy(x => x.ReportDate);
+        }
+        private async Task<Dictionary<long, double>> GetTongGiaoDichTheoChiNhanhRequestApproved(
+            Dictionary<CurrencyYearMonthDto, double> dicCurrencyConvert,
+            DateTime startDate, DateTime endDate)
+        {
+            var statusApprovedId = await _commonManager.GetStatusIdByCode(FinanceManagementConsts.WORKFLOW_STATUS_APPROVED.Trim());
+
+            var result = await (from obt in WorkScope.GetAll<OutcomingEntryBankTransaction>()
+                    join oe in WorkScope.GetAll<OutcomingEntry>() on obt.OutcomingEntryId equals oe.Id
+                    join bt in WorkScope.GetAll<BankTransaction>() on obt.BankTransactionId equals bt.Id
+                    where oe.WorkflowStatusId == statusApprovedId
+                        && oe.ReportDate >= startDate && oe.ReportDate <= endDate
+                    select new
+                    {
+                        oe.BranchId,
+                        bt.CurrencyId,
+                        bt.TransactionDate,
+                        bt.Amount
+                    })
+                    .AsEnumerable() // để sử dụng convert bằng C#
+                    .Select(x => new
+                    {
+                        x.BranchId,
+                        AmountVND = x.Amount * GetExchangeRateByDicCurrencyConvert(dicCurrencyConvert, x.CurrencyId, x.TransactionDate)
+                    })
+                    .GroupBy(x => x.BranchId)
+                    .ToDictionaryAsync(g => g.Key, g => g.Sum(x => x.AmountVND));
+
+            return result;
         }
         private IQueryable<GetThongTinRequestChi> IQOutcomingEntryForDashboard(long? statusEndId = null)
         {

--- a/aspnet-core/src/FinanceManagement.Core/Managers/Dashboards/DashboardManager.cs
+++ b/aspnet-core/src/FinanceManagement.Core/Managers/Dashboards/DashboardManager.cs
@@ -1097,6 +1097,7 @@ namespace FinanceManagement.Managers.Dashboards
                 Details = x.Details
             }).OrderBy(x => x.ReportDate);
         }
+
         private async Task<Dictionary<long, double>> GetTongGiaoDichTheoChiNhanhRequestApproved(
             Dictionary<CurrencyYearMonthDto, double> dicCurrencyConvert,
             DateTime startDate,
@@ -1105,29 +1106,35 @@ namespace FinanceManagement.Managers.Dashboards
         {
             var statusApprovedId = await _commonManager.GetStatusIdByCode(FinanceManagementConsts.WORKFLOW_STATUS_APPROVED.Trim());
 
-            var result = await (from obt in _ws.GetAll<OutcomingEntryBankTransaction>()
-                    join oe in _ws.GetAll<OutcomingEntry>() on obt.OutcomingEntryId equals oe.Id
-                    join bt in _ws.GetAll<BankTransaction>() on obt.BankTransactionId equals bt.Id
-                    where oe.WorkflowStatusId == statusApprovedId
-                        && oe.ReportDate >= startDate && oe.ReportDate <= endDate
-                    select new
-                    {
-                        oe.BranchId,
-                        CurrencyId = bt.FromBankAccount.CurrencyId,
-                        bt.TransactionDate,
-                        Amount = bt.FromValue
-                    })
-                    .AsEnumerable()
-                    .Select(x => new
-                    {
-                        x.BranchId,
-                        AmountVND = x.Amount * GetExchangeRateByDicCurrencyConvert(dicCurrencyConvert, x.CurrencyId, x.TransactionDate)
-                    })
-                    .GroupBy(x => x.BranchId)
-                    .ToDictionaryAsync(g => g.Key, g => g.Sum(x => x.AmountVND));
+            var result = (from obt in _ws.GetAll<OutcomingEntryBankTransaction>()
+                  join oe in _ws.GetAll<OutcomingEntry>() on obt.OutcomingEntryId equals oe.Id
+                  join bt in _ws.GetAll<BankTransaction>() on obt.BankTransactionId equals bt.Id
+                  join fba in _ws.GetAll<BankAccount>() on bt.FromBankAccountId equals fba.Id
+                  where oe.WorkflowStatusId == statusApprovedId
+                      && oe.ReportDate >= startDate && oe.ReportDate <= endDate
+                  select new
+                  {
+                      oe.BranchId,
+                      CurrencyId = fba.CurrencyId,
+                      TransactionDate = bt.TransactionDate,
+                      Amount = bt.FromValue
+                  })
+                  .AsEnumerable()
+                  .Select(x => new
+                  {
+                      x.BranchId,
+                      AmountVND = x.Amount * GetExchangeRateByDicCurrencyConvert(dicCurrencyConvert, x.CurrencyId, x.TransactionDate)
+                  })
+                  .GroupBy(x => x.BranchId)
+                  .ToDictionary(
+                      g => g.Key,
+                      g => g.Sum(x => x.AmountVND)
+                  );
 
             return result;
         }
+
+
         private IQueryable<GetThongTinRequestChi> IQOutcomingEntryForDashboard(long? statusEndId = null)
         {
             return _ws.GetAll<OutcomingEntry>()

--- a/aspnet-core/src/FinanceManagement.Core/Managers/Dashboards/DashboardManager.cs
+++ b/aspnet-core/src/FinanceManagement.Core/Managers/Dashboards/DashboardManager.cs
@@ -1097,32 +1097,31 @@ namespace FinanceManagement.Managers.Dashboards
                 Details = x.Details
             }).OrderBy(x => x.ReportDate);
         }
-
         private async Task<Dictionary<long, double>> GetTongGiaoDichTheoChiNhanhRequestApproved(
-            Dictionary<CurrencyYearMonthDto, double> dicCurrencyConvert,
-            DateTime startDate,
-            DateTime endDate
+        Dictionary<CurrencyYearMonthDto, double> dicCurrencyConvert,
+        DateTime startDate,
+        DateTime endDate
         )
         {
-            var statusApprovedId = await _commonManager.GetStatusIdByCode(FinanceManagementConsts.WORKFLOW_STATUS_APPROVED.Trim());
+    var statusApprovedId = await _commonManager.GetStatusIdByCode(FinanceManagementConsts.WORKFLOW_STATUS_APPROVED.Trim());
 
-            var result = (from obt in _ws.GetAll<OutcomingEntryBankTransaction>()
+    var result = (from obt in _ws.GetAll<OutcomingEntryBankTransaction>()
                   join oe in _ws.GetAll<OutcomingEntry>() on obt.OutcomingEntryId equals oe.Id
                   join bt in _ws.GetAll<BankTransaction>() on obt.BankTransactionId equals bt.Id
                   where oe.WorkflowStatusId == statusApprovedId
-                    && oe.ReportDate >= startDate && oe.ReportDate <= endDate
+                        && oe.ReportDate >= startDate && oe.ReportDate <= endDate
                   select new
                   {
                       oe.BranchId,
-                      CurrencyId = oe.CurrencyId,                 // ✅ Dùng từ request chi
-                      TransactionDate = oe.ReportDate,            // ✅ Dùng từ request chi
-                      Amount = bt.FromValue
+                      oe.CurrencyId,          // ✅ lấy theo request chi
+                      oe.ReportDate,
+                      Amount = bt.FromValue   // ✅ tổng theo bank transaction
                   })
                   .AsEnumerable()
                   .Select(x => new
                   {
                       x.BranchId,
-                      AmountVND = x.Amount * GetExchangeRateByDicCurrencyConvert(dicCurrencyConvert, x.CurrencyId, x.TransactionDate)
+                      AmountVND = x.Amount * GetExchangeRateByDicCurrencyConvert(dicCurrencyConvert, x.CurrencyId ?? 0, x.ReportDate)
                   })
                   .GroupBy(x => x.BranchId)
                   .ToDictionary(
@@ -1130,7 +1129,7 @@ namespace FinanceManagement.Managers.Dashboards
                       g => g.Sum(x => x.AmountVND)
                   );
 
-            return result;
+    return result;
         }
         private IQueryable<GetThongTinRequestChi> IQOutcomingEntryForDashboard(long? statusEndId = null)
         {

--- a/aspnet-core/src/FinanceManagement.Core/Managers/Dashboards/DashboardManager.cs
+++ b/aspnet-core/src/FinanceManagement.Core/Managers/Dashboards/DashboardManager.cs
@@ -1121,7 +1121,7 @@ namespace FinanceManagement.Managers.Dashboards
                   .Select(x => new
                   {
                       x.BranchId,
-                      AmountVND = x.Amount * GetExchangeRateByDicCurrencyConvert(dicCurrencyConvert, x.CurrencyId ?? 0, x.ReportDate)
+                      AmountVND = x.Amount * GetExchangeRateByDicCurrencyConvert(dicCurrencyConvert, x.CurrencyId ?? 1, x.ReportDate)
                   })
                   .GroupBy(x => x.BranchId)
                   .ToDictionary(

--- a/aspnet-core/src/FinanceManagement.Core/Managers/Dashboards/DashboardManager.cs
+++ b/aspnet-core/src/FinanceManagement.Core/Managers/Dashboards/DashboardManager.cs
@@ -1099,13 +1099,15 @@ namespace FinanceManagement.Managers.Dashboards
         }
         private async Task<Dictionary<long, double>> GetTongGiaoDichTheoChiNhanhRequestApproved(
             Dictionary<CurrencyYearMonthDto, double> dicCurrencyConvert,
-            DateTime startDate, DateTime endDate)
+            DateTime startDate,
+            DateTime endDate
+        )
         {
             var statusApprovedId = await _commonManager.GetStatusIdByCode(FinanceManagementConsts.WORKFLOW_STATUS_APPROVED.Trim());
 
-            var result = await (from obt in WorkScope.GetAll<OutcomingEntryBankTransaction>()
-                    join oe in WorkScope.GetAll<OutcomingEntry>() on obt.OutcomingEntryId equals oe.Id
-                    join bt in WorkScope.GetAll<BankTransaction>() on obt.BankTransactionId equals bt.Id
+            var result = await (from obt in _ws.GetAll<OutcomingEntryBankTransaction>()
+                    join oe in _ws.GetAll<OutcomingEntry>() on obt.OutcomingEntryId equals oe.Id
+                    join bt in _ws.GetAll<BankTransaction>() on obt.BankTransactionId equals bt.Id
                     where oe.WorkflowStatusId == statusApprovedId
                         && oe.ReportDate >= startDate && oe.ReportDate <= endDate
                     select new

--- a/aspnet-core/src/FinanceManagement.Core/Managers/Dashboards/DashboardManager.cs
+++ b/aspnet-core/src/FinanceManagement.Core/Managers/Dashboards/DashboardManager.cs
@@ -1103,23 +1103,21 @@ namespace FinanceManagement.Managers.Dashboards
             DateTime endDate
         )
         {
-            // Lấy status đã duyệt
             var statusApprovedId = await _commonManager.GetStatusIdByCode(
             FinanceManagementConsts.WORKFLOW_STATUS_APPROVED.Trim()
             );
 
-            // Truy vấn dữ liệu
             var result = (from obt in _ws.GetAll<OutcomingEntryBankTransaction>()
                   join oe in _ws.GetAll<OutcomingEntry>() on obt.OutcomingEntryId equals oe.Id
                   join bt in _ws.GetAll<BankTransaction>() on obt.BankTransactionId equals bt.Id
                   where oe.WorkflowStatusId == statusApprovedId
-                    && oe.ApprovedTime >= startDate
-                    && oe.ApprovedTime <= endDate
+                    && bt.TransactionDate >= startDate
+                    && bt.TransactionDate <= endDate
                   select new
                   {
                       oe.BranchId,
                       oe.CurrencyId,
-                      oe.ApprovedTime,
+                      bt.TransactionDate,
                       Amount = bt.FromValue
                   })
                   .AsEnumerable()
@@ -1129,7 +1127,7 @@ namespace FinanceManagement.Managers.Dashboards
                       AmountVND = x.Amount * GetExchangeRateByDicCurrencyConvert(
                       dicCurrencyConvert,
                       x.CurrencyId ?? 1,
-                      x.ApprovedTime
+                      x.TransactionDate
                       )
                   })
                   .GroupBy(x => x.BranchId)
@@ -1140,6 +1138,7 @@ namespace FinanceManagement.Managers.Dashboards
 
             return result;
         }
+
         private IQueryable<GetThongTinRequestChi> IQOutcomingEntryForDashboard(long? statusEndId = null)
         {
             return _ws.GetAll<OutcomingEntry>()

--- a/aspnet-core/src/FinanceManagement.Core/Managers/Dashboards/DashboardManager.cs
+++ b/aspnet-core/src/FinanceManagement.Core/Managers/Dashboards/DashboardManager.cs
@@ -1103,30 +1103,42 @@ namespace FinanceManagement.Managers.Dashboards
             DateTime endDate
         )
         {
-            var statusApprovedId = await _commonManager.GetStatusIdByCode(FinanceManagementConsts.WORKFLOW_STATUS_APPROVED.Trim());
+            // Lấy status đã duyệt
+            var statusApprovedId = await _commonManager.GetStatusIdByCode(
+            FinanceManagementConsts.WORKFLOW_STATUS_APPROVED.Trim()
+            );
 
+            // Truy vấn dữ liệu
             var result = (from obt in _ws.GetAll<OutcomingEntryBankTransaction>()
                   join oe in _ws.GetAll<OutcomingEntry>() on obt.OutcomingEntryId equals oe.Id
                   join bt in _ws.GetAll<BankTransaction>() on obt.BankTransactionId equals bt.Id
                   where oe.WorkflowStatusId == statusApprovedId
-                    && oe.ReportDate >= startDate && oe.ReportDate <= endDate
+                    && oe.ApprovedTime >= startDate
+                    && oe.ApprovedTime <= endDate
                   select new
                   {
                       oe.BranchId,
-                      CurrencyId = oe.CurrencyId ?? 1, // dùng currency của OutcomingEntry
-                      oe.ReportDate,
-                      bt.FromValue
+                      oe.CurrencyId,
+                      oe.ApprovedTime,
+                      Amount = bt.FromValue
                   })
                   .AsEnumerable()
                   .Select(x => new
                   {
                       x.BranchId,
-                      AmountVND = x.FromValue * GetExchangeRateByDicCurrencyConvert(dicCurrencyConvert, x.CurrencyId, x.ReportDate)
+                      AmountVND = x.Amount * GetExchangeRateByDicCurrencyConvert(
+                      dicCurrencyConvert,
+                      x.CurrencyId ?? 1,
+                      x.ApprovedTime
+                      )
                   })
                   .GroupBy(x => x.BranchId)
-                  .ToDictionary(g => g.Key, g => g.Sum(x => x.AmountVND));
+                  .ToDictionary(
+                      g => g.Key,
+                      g => g.Sum(x => x.AmountVND)
+                  );
 
-    return result;
+            return result;
         }
         private IQueryable<GetThongTinRequestChi> IQOutcomingEntryForDashboard(long? statusEndId = null)
         {

--- a/aspnet-core/src/FinanceManagement.Core/Managers/Dashboards/DashboardManager.cs
+++ b/aspnet-core/src/FinanceManagement.Core/Managers/Dashboards/DashboardManager.cs
@@ -1098,36 +1098,33 @@ namespace FinanceManagement.Managers.Dashboards
             }).OrderBy(x => x.ReportDate);
         }
         private async Task<Dictionary<long, double>> GetTongGiaoDichTheoChiNhanhRequestApproved(
-        Dictionary<CurrencyYearMonthDto, double> dicCurrencyConvert,
-        DateTime startDate,
-        DateTime endDate
+            Dictionary<CurrencyYearMonthDto, double> dicCurrencyConvert,
+            DateTime startDate,
+            DateTime endDate
         )
         {
-    var statusApprovedId = await _commonManager.GetStatusIdByCode(FinanceManagementConsts.WORKFLOW_STATUS_APPROVED.Trim());
+            var statusApprovedId = await _commonManager.GetStatusIdByCode(FinanceManagementConsts.WORKFLOW_STATUS_APPROVED.Trim());
 
-    var result = (from obt in _ws.GetAll<OutcomingEntryBankTransaction>()
+            var result = (from obt in _ws.GetAll<OutcomingEntryBankTransaction>()
                   join oe in _ws.GetAll<OutcomingEntry>() on obt.OutcomingEntryId equals oe.Id
                   join bt in _ws.GetAll<BankTransaction>() on obt.BankTransactionId equals bt.Id
                   where oe.WorkflowStatusId == statusApprovedId
-                        && oe.ReportDate >= startDate && oe.ReportDate <= endDate
+                    && oe.ReportDate >= startDate && oe.ReportDate <= endDate
                   select new
                   {
                       oe.BranchId,
-                      oe.CurrencyId,          // ✅ lấy theo request chi
+                      CurrencyId = oe.CurrencyId ?? 1, // dùng currency của OutcomingEntry
                       oe.ReportDate,
-                      Amount = bt.FromValue   // ✅ tổng theo bank transaction
+                      bt.FromValue
                   })
                   .AsEnumerable()
                   .Select(x => new
                   {
                       x.BranchId,
-                      AmountVND = x.Amount * GetExchangeRateByDicCurrencyConvert(dicCurrencyConvert, x.CurrencyId ?? 1, x.ReportDate)
+                      AmountVND = x.FromValue * GetExchangeRateByDicCurrencyConvert(dicCurrencyConvert, x.CurrencyId, x.ReportDate)
                   })
                   .GroupBy(x => x.BranchId)
-                  .ToDictionary(
-                      g => g.Key,
-                      g => g.Sum(x => x.AmountVND)
-                  );
+                  .ToDictionary(g => g.Key, g => g.Sum(x => x.AmountVND));
 
     return result;
         }

--- a/aspnet-core/src/FinanceManagement.Core/Managers/Dashboards/DashboardManager.cs
+++ b/aspnet-core/src/FinanceManagement.Core/Managers/Dashboards/DashboardManager.cs
@@ -987,14 +987,14 @@ namespace FinanceManagement.Managers.Dashboards
                     TotalVND = x.Sum(s => s.TotalVND)
                 })
                 .ToDictionary(x => x.BranchId, x => x.TotalVND);
-            var tongGiaoDichTheoBranchRequestApproved = await GetTongGiaoDichTheoChiNhanhRequestApproved(dicCurrencyConvert, startDate, endDate);
+            var tongGiaoDichTheoChiNhanhRequestApproved = await GetTongGiaoDichTheoChiNhanhRequestApproved(dicCurrencyConvert, startDate, endDate);
             //lay theo thu
             var qtongThu = await GetDataBaoCaoThu(startDate, endDate, dicCurrencyConvert, null);
 
             foreach (var dto in tongChiTheoChiNhanh)
             {
                 dto.TongChiThuc = tongChiThucTheoChiNhanh.ContainsKey(dto.BranchId) ? tongChiThucTheoChiNhanh[dto.BranchId] : 0;
-                dto.TongGiaoDichNganHangApproved = tongGiaoDichTheoBranchRequestApproved.ContainsKey(dto.BranchId) ? tongGiaoDichTheoBranch[dto.BranchId] : 0;
+                dto.TongGiaoDichNganHangApproved = tongGiaoDichTheoChiNhanhRequestApproved.ContainsKey(dto.BranchId) ? tongGiaoDichTheoChiNhanhRequestApproved[dto.BranchId] : 0;
             }
 
             var tong = new BaoCaoChungDto

--- a/aspnet-core/src/FinanceManagement.Core/Managers/Dashboards/DashboardManager.cs
+++ b/aspnet-core/src/FinanceManagement.Core/Managers/Dashboards/DashboardManager.cs
@@ -1113,11 +1113,11 @@ namespace FinanceManagement.Managers.Dashboards
                     select new
                     {
                         oe.BranchId,
-                        bt.CurrencyId,
+                        CurrencyId = bt.FromBankAccount.CurrencyId,
                         bt.TransactionDate,
-                        bt.Amount
+                        Amount = bt.FromValue
                     })
-                    .AsEnumerable() // để sử dụng convert bằng C#
+                    .AsEnumerable()
                     .Select(x => new
                     {
                         x.BranchId,

--- a/aspnet-core/src/FinanceManagement.Core/Managers/Dashboards/DashboardManager.cs
+++ b/aspnet-core/src/FinanceManagement.Core/Managers/Dashboards/DashboardManager.cs
@@ -1109,14 +1109,13 @@ namespace FinanceManagement.Managers.Dashboards
             var result = (from obt in _ws.GetAll<OutcomingEntryBankTransaction>()
                   join oe in _ws.GetAll<OutcomingEntry>() on obt.OutcomingEntryId equals oe.Id
                   join bt in _ws.GetAll<BankTransaction>() on obt.BankTransactionId equals bt.Id
-                  join fba in _ws.GetAll<BankAccount>() on bt.FromBankAccountId equals fba.Id
                   where oe.WorkflowStatusId == statusApprovedId
-                      && oe.ReportDate >= startDate && oe.ReportDate <= endDate
+                    && oe.ReportDate >= startDate && oe.ReportDate <= endDate
                   select new
                   {
                       oe.BranchId,
-                      CurrencyId = fba.CurrencyId,
-                      TransactionDate = bt.TransactionDate,
+                      CurrencyId = oe.CurrencyId,                 // ✅ Dùng từ request chi
+                      TransactionDate = oe.ReportDate,            // ✅ Dùng từ request chi
                       Amount = bt.FromValue
                   })
                   .AsEnumerable()
@@ -1133,8 +1132,6 @@ namespace FinanceManagement.Managers.Dashboards
 
             return result;
         }
-
-
         private IQueryable<GetThongTinRequestChi> IQOutcomingEntryForDashboard(long? statusEndId = null)
         {
             return _ws.GetAll<OutcomingEntry>()

--- a/aspnet-core/src/FinanceManagement.Core/Managers/Dashboards/Dtos/BaoCaoChungDto.cs
+++ b/aspnet-core/src/FinanceManagement.Core/Managers/Dashboards/Dtos/BaoCaoChungDto.cs
@@ -29,6 +29,7 @@ namespace FinanceManagement.Managers.Dashboards.Dtos
         public string ThuKhongThucFormat => Helpers.FormatMoney(ThuKhongThuc);
         public double ChenhLech => Du - DuThuc;
         public string ChenhLechFormat => Helpers.FormatMoney(ChenhLech);
+        public double TongGiaoDichNganHangApproved { get; set; }
     }
     public class GetThongTinRequestChi
     {


### PR DESCRIPTION
- Hiện tại, để ra dashboard (Tổng chi/tổng chi thực), cần request chi có trạng thái END.
- Thực tế, chi lương HRM hầu như cả tháng luôn ở trạng thái APPROVED (mới chi 1 phần, còn vài triệu giữ lại vì các case nghỉ việc không nộp hồ sơ), không sang END được ---> Báo cáo chi theo tháng luôn bị thiếu (và lại là khoản lớn nhất).
- Sửa thêm field: tongGiaoDichNganHangApproved (đã có convert VND): Tính tất cả các linked Bank Transaction đến các Approved Request, với transaction date trong tháng.
- Dùng field này để tự tổng sum tổng chi/tổng chi thực của N8N - Resource Bot. Chưa cộng vào field tổng chi/tổng chi thực ở dashboard finfast.

CẦN THẢO LUẬN: Có nhét thêm field này vào giá trị tổng của tổng chi/tổng chi thực không.